### PR TITLE
Add threshold input to filter low-confidence detections

### DIFF
--- a/grounded_sam.py
+++ b/grounded_sam.py
@@ -75,10 +75,11 @@ def draw_mask(mask, image, random_color=True):
 
 
 def run_grounding_sam(local_image_path, positive_prompt, negative_prompt, groundingdino_model, sam_predictor,
-                      adjustment_factor):
+                      adjustment_factor, threshold=0.3):
     image_source, image = load_image(local_image_path)
 
-    annotated_frame, detected_boxes = detect(image, image_source, positive_prompt, groundingdino_model)
+    annotated_frame, detected_boxes = detect(image, image_source, positive_prompt, groundingdino_model,
+                                             box_threshold=threshold)
 
     segmented_frame_masks = segment(image_source, sam_predictor, boxes=detected_boxes)
 
@@ -95,7 +96,8 @@ def run_grounding_sam(local_image_path, positive_prompt, negative_prompt, ground
 
     # If negative_prompt is defined and not empty, process negative mask
     if negative_prompt:
-        neg_annotated_frame, neg_detected_boxes = detect(image, image_source, negative_prompt, groundingdino_model)
+        neg_annotated_frame, neg_detected_boxes = detect(image, image_source, negative_prompt, groundingdino_model,
+                                                          box_threshold=threshold)
 
         neg_segmented_frame_masks = segment(image_source, sam_predictor, boxes=neg_detected_boxes)
 

--- a/predict.py
+++ b/predict.py
@@ -69,6 +69,12 @@ class Predictor(BasePredictor):
                 description="Mask Adjustment Factor (-ve for erosion, +ve for dilation)",
                 default=0,
             ),
+            threshold: float = Input(
+                description="Confidence threshold for object detection (0.0–1.0). Detections below this score are discarded.",
+                default=0.3,
+                ge=0.0,
+                le=1.0,
+            ),
     ) -> Iterator[Path]:
         """Run a single prediction on the model"""
         predict_id = str(uuid.uuid4())
@@ -80,7 +86,8 @@ class Predictor(BasePredictor):
                                                                                                     negative_mask_prompt,
                                                                                                     self.groundingdino_model,
                                                                                                     self.sam_predictor,
-                                                                                                    adjustment_factor)
+                                                                                                    adjustment_factor,
+                                                                                                    threshold)
         print("Done!")
 
         variable_dict = {


### PR DESCRIPTION
While using this model I noticed it sometimes detects objects that aren't actually present in the image. These false detections still pass the current hardcoded `box_threshold=0.3` in `detect()`, meaning the threshold alone isn't always tight enough.

This PR exposes `box_threshold` as a user-facing threshold input in the Replicate predictor, so callers can tune it without touching the code. The default stays at 0.3 to preserve existing behavior.

Changes:

- Added threshold: float Input to predict.py (range 0.0–1.0, default 0.3)
- Threaded it through run_grounding_sam, both detect() calls (positive and negative prompts.